### PR TITLE
refactor: Replace if-else block with switch statement in Wader

### DIFF
--- a/src/main/java/Wader/Wader.java
+++ b/src/main/java/Wader/Wader.java
@@ -38,27 +38,28 @@ public class Wader {
         try {
             Parser.Command command = Parser.parse(userInput);
 
-            if (command.getType() == Parser.CommandType.BYE) {
-                storage.save(tasks);
-                return ui.showGoodbyeMessage();
-            } else if (command.getType() == Parser.CommandType.LIST) {
-                return ui.showTaskList(tasks);
-            } else if (command.getType() == Parser.CommandType.MARK) {
-                return handleMarkAndGetResponse(command.getFullCommand(), tasks);
-            } else if (command.getType() == Parser.CommandType.UNMARK) {
-                return handleUnmarkAndGetResponse(command.getFullCommand(), tasks);
-            } else if (command.getType() == Parser.CommandType.TODO) {
-                return handleTodoAndGetResponse(command.getFullCommand(), tasks);
-            } else if (command.getType() == Parser.CommandType.DEADLINE) {
-                return handleDeadlineAndGetResponse(command.getFullCommand(), tasks);
-            } else if (command.getType() == Parser.CommandType.EVENT) {
-                return handleEventAndGetResponse(command.getFullCommand(), tasks);
-            } else if (command.getType() == Parser.CommandType.DELETE) {
-                return handleDeleteAndGetResponse(command.getFullCommand(), tasks);
-            } else if (command.getType() == Parser.CommandType.FIND) {
-                return handleFindAndGetResponse(command.getFullCommand(), tasks);
-            } else {
-                throw new DukeException("OOPS!!! I'm sorry, but I don't know what that means :-(");
+            switch (command.getType()) {
+                case BYE:
+                    storage.save(tasks);
+                    return ui.showGoodbyeMessage();
+                case LIST:
+                    return ui.showTaskList(tasks);
+                case MARK:
+                    return handleMarkAndGetResponse(command.getFullCommand(), tasks);
+                case UNMARK:
+                    return handleUnmarkAndGetResponse(command.getFullCommand(), tasks);
+                case TODO:
+                    return handleTodoAndGetResponse(command.getFullCommand(), tasks);
+                case DEADLINE:
+                    return handleDeadlineAndGetResponse(command.getFullCommand(), tasks);
+                case EVENT:
+                    return handleEventAndGetResponse(command.getFullCommand(), tasks);
+                case DELETE:
+                    return handleDeleteAndGetResponse(command.getFullCommand(), tasks);
+                case FIND:
+                    return handleFindAndGetResponse(command.getFullCommand(), tasks);
+                default:
+                    throw new DukeException("OOPS!!! I'm sorry, but I don't know what that means :-(");
             }
         } catch (DukeException e) {
             return ui.showError(e.getMessage());


### PR DESCRIPTION
Refactored the `getResponse` method in the Wader class to replace the verbose if-else block with a cleaner switch statement. This improves readability and maintainability by simplifying the logic for handling different command types.

### Changes:
- Replaced the if-else block in `getResponse` with a switch statement.
- Ensured all command types (BYE, LIST, MARK, UNMARK, TODO, DEADLINE, EVENT, DELETE, FIND) are handled in the switch.
- Added a default case to throw a `DukeException` for unknown commands.

### Benefits:
- Improved code readability and maintainability.
- Simplified logic for handling user commands.
- Enhanced scalability for adding new command types in the future.

This refactor ensures cleaner architecture and prepares the codebase for